### PR TITLE
Removes arrow from navigate.js appended Exit App menu item

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -206,3 +206,8 @@ body.disableScroll {
 .hamburger.is-active .hamburger-inner::after {
   background-color: #333333;
 }
+
+/* Removes arrow from navigate.js appended Exit App menu item */
+[data-fl-exit-app].fa-angle-right.linked-icon {
+  display: none;
+}


### PR DESCRIPTION
- This menu item won't have an icon by default. The user will be forced to set up an exit link if an icon menu is used.