### PR TITLE
Menu icon component  and edit menu component overlay are shown on the same side

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -23,6 +23,10 @@ body.disableScroll {
   z-index: 10;
 }
 
+.fl-menu-circle-move-left {
+  left: 15px !important;
+}
+
 .fl-menu-circle-header {
   position: fixed;
   bottom: 15px;

--- a/js/menu.js
+++ b/js/menu.js
@@ -30,8 +30,10 @@ function init() {
 
   if (data.location) {
     $('body').addClass('fl-menu-circle-left');
+    $menuElement.addClass('fl-menu-circle-move-left');
   } else {
     $('body').addClass('fl-menu-circle-right');
+    $menuElement.removeClass('fl-menu-circle-move-left');
   }
 
   $('.fl-menu-circle-header .nav-toggle').on('click', function() {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5036

## Description
Added class that moves edit-window left if left alignment is selected.

## Screenshots/screencasts
<img width="751" alt="menu" src="https://user-images.githubusercontent.com/52824207/70066285-1911f700-15f5-11ea-8815-d7a632f5ff8d.png">

## Backward compatibility
This change is fully backward compatible.