### PR TITLE
[Fix] Do not disable the cancel button when the menu is loaded.

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -25,8 +25,6 @@ Fliplet.Widget.onSaveRequest(function() {
   });
 });
 
-Fliplet.Widget.toggleCancelButton(false);
-
 Fliplet.Widget.onCancelRequest(function() {
   Fliplet.Widget.complete();
   Fliplet.Studio.emit('reload-page-preview');


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6403

## Description
Do not disable the cancel button when the menu is loaded.

## Screenshots/screencasts
https://share.getcloudapp.com/BluO5y2J

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
Previously we are used `Fliplet.Widget.toggleCancelButton(false)`, to enable listener on `cancel-button-pressed` but it seems now it works differently that is why we are removing `Fliplet.Widget.toggleCancelButton(false)`