### PR TITLE
PS-1810: Deduplicate menu pages on render (#31)

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -20,17 +20,19 @@ function init() {
 
   if (data.pages) {
     data.pages = data.pages.filter(function(page) {
-      return !page.pageId || !masterPageIds[page.pageId];
+      return !(page.pageId && masterPageIds[page.pageId]);
     });
   }
 
-  // Also remove already-rendered DOM elements for master pages
-  $menuElement.find('li[data-page-id]').each(function() {
-    var pageId = $(this).attr('data-page-id');
+  // Remove already-rendered DOM elements for master pages after template is ready
+  Fliplet().then(function() {
+    $menuElement.find('li[data-page-id]').each(function() {
+      var pageId = $(this).attr('data-page-id');
 
-    if (pageId && masterPageIds[pageId]) {
-      $(this).remove();
-    }
+      if (pageId && masterPageIds[pageId]) {
+        $(this).remove();
+      }
+    });
   });
 
   Fliplet.Hooks.on('addExitAppMenuLink', function() {

--- a/js/menu.js
+++ b/js/menu.js
@@ -8,6 +8,31 @@ if (menuInstanceId) {
 function init() {
   var data = Fliplet.Widget.getData(menuInstanceId) || {};
 
+  // Remove stale master page references that should have been replaced by production pages
+  var appPages = Fliplet.Env.get('appPages') || [];
+  var masterPageIds = {};
+
+  appPages.forEach(function(p) {
+    if (p.masterPageId) {
+      masterPageIds[p.masterPageId] = true;
+    }
+  });
+
+  if (data.pages) {
+    data.pages = data.pages.filter(function(page) {
+      return !page.pageId || !masterPageIds[page.pageId];
+    });
+  }
+
+  // Also remove already-rendered DOM elements for master pages
+  $menuElement.find('li[data-page-id]').each(function() {
+    var pageId = $(this).attr('data-page-id');
+
+    if (pageId && masterPageIds[pageId]) {
+      $(this).remove();
+    }
+  });
+
   Fliplet.Hooks.on('addExitAppMenuLink', function() {
     var $exitButton = $([
       '<li class="linked with-icon" data-fl-exit-app>',


### PR DESCRIPTION
* Deduplicate data.pages to fix corrupted menu data rendering

Filter duplicate pages by pageId after getData() to prevent duplicated menu items from displaying in the UI.

Ref: PS-1810



* Filter stale master pages and remove duplicated DOM elements

Use Fliplet.Env.get('appPages') masterPageId mapping to filter data.pages and remove already-rendered li elements from build.html.



---------