### PR TITLE
PS-1939: Preserve logout items in master-page DOM cleanup

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -29,9 +29,24 @@ function init() {
     $menuElement.find('li[data-page-id]').each(function() {
       var pageId = $(this).attr('data-page-id');
 
-      if (pageId && masterPageIds[pageId]) {
-        $(this).remove();
+      if (!pageId || !masterPageIds[pageId]) {
+        return;
       }
+
+      // Preserve logout items whose target screen happens to be a master page (PS-1939)
+      var nav = {};
+
+      try {
+        nav = JSON.parse($(this).attr('data-fl-navigate') || '{}');
+      } catch (e) {
+        // Malformed JSON — fall through and remove
+      }
+
+      if (nav.action === 'logout') {
+        return;
+      }
+
+      $(this).remove();
     });
   });
 


### PR DESCRIPTION
## Summary
- The PS-1810 cleanup pass in `js/menu.js` removes menu items whose `data-page-id` matches a master page ID. When a Log Out item happens to target a master page, it gets stripped too — same root cause as the bottom-bar regression filed in PS-1939.
- Skip items whose `data-fl-navigate` action is `logout` so they survive the deduplication. JSON parse is wrapped in try/catch; malformed JSON falls through to the original remove path.
- The cleanup runs inside `Fliplet().then(...)`, which is why the item briefly renders before disappearing.

## Test plan
- [ ] Open an app whose Log Out menu item targets a master page using the Circle menu — Log Out remains visible after page load (no flash).
- [ ] Log Out still navigates correctly (`Fliplet.Navigate.exitApp()` not impacted).
- [ ] Items that *do* duplicate a master page (non-logout) are still removed.
- [ ] Master-page items with malformed `data-fl-navigate` JSON still get removed.

Linked: PS-1810 (regression source), PS-1939 (ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)